### PR TITLE
Bump plutus version 1.23.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,13 +10,13 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 source-repository-package
-  type: git
-  location: https://github.com/albertodvp/plutarch-plutus
-  tag: 1b2b5fb684e69e3d12319608278c1f6dea6e12af
-  subdir:
-    .
-    plutarch-ledger-api
-    plutarch-extra
+    type: git
+    location: https://github.com/Plutonomicon/plutarch-plutus
+    tag: fcdd2209433d8b8979e820dc4fa9aad5f202216d
+    subdir:
+      .
+      plutarch-ledger-api
+      plutarch-extra
 
 packages:
   ./*

--- a/cabal.project
+++ b/cabal.project
@@ -10,13 +10,13 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 source-repository-package
-    type: git
-    location: https://github.com/Plutonomicon/plutarch-plutus
-    tag: a170ce4763891e24f59572209722edf2874a7d83
-    subdir:
-      .
-      plutarch-ledger-api
-      plutarch-extra
+  type: git
+  location: https://github.com/albertodvp/plutarch-plutus
+  tag: 1b2b5fb684e69e3d12319608278c1f6dea6e12af
+  subdir:
+    .
+    plutarch-ledger-api
+    plutarch-extra
 
 packages:
   ./*
@@ -25,4 +25,4 @@ tests: true
 test-show-details: direct
 
 constraints:
-  , plutus-core == 1.20.0.0
+  , plutus-core == 1.23.0.0

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/Precompile.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/Precompile.hs
@@ -55,7 +55,6 @@ import Plutarch.Lift (
   plift',
  )
 import Plutarch.Script (Script (Script))
-import PlutusCore.Builtin (KnownTypeError (KnownTypeEvaluationFailure, KnownTypeUnliftingError))
 import UntypedPlutusCore qualified as UPLC
 
 {- | Type-safe wrapper for compiled Plutarch functions.
@@ -224,12 +223,7 @@ liftErrorMsg :: LiftError -> String
 -- anyway.
 liftErrorMsg = \case
   LiftError_FromRepr -> "pconstantFromRepr returned 'Nothing'"
-  LiftError_KnownTypeError e ->
-    case e of
-      KnownTypeUnliftingError unliftErr ->
-        "incorrect type: " <> show unliftErr
-      KnownTypeEvaluationFailure ->
-        "absurd evaluation failure"
+  LiftError_KnownTypeError e -> "incorrect type: " <> show e
   LiftError_EvalError e -> "erring term: " <> show e
   LiftError_CompilationError msg -> "compilation failed: " <> Text.unpack msg
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -6,7 +6,8 @@ pkgs.haskell-nix.cabalProject'
   shell = import ./shell.nix { inherit pkgs; };
   inputMap = {
     "https://chap.intersectmbo.org/" = inputs.CHaP;
-    "https://github.com/Plutonomicon/plutarch-plutus.git" = inputs.plutarch;
   };
-  sha256map = { "https://github.com/Plutonomicon/plutarch-plutus"."a170ce4763891e24f59572209722edf2874a7d83" = "sha256-ZIKSI6zVmBd6trzx7W46sshTv+oLW97FnPERAnBlhhc="; };
+  sha256map = {
+    "https://github.com/albertodvp/plutarch-plutus"."1b2b5fb684e69e3d12319608278c1f6dea6e12af" = "sha256-xViZbZlq5Sw9rHakS9nwcQikCOfwZClSBL8UD+5eJJ4=";
+  };
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -8,6 +8,6 @@ pkgs.haskell-nix.cabalProject'
     "https://chap.intersectmbo.org/" = inputs.CHaP;
   };
   sha256map = {
-    "https://github.com/albertodvp/plutarch-plutus"."1b2b5fb684e69e3d12319608278c1f6dea6e12af" = "sha256-xViZbZlq5Sw9rHakS9nwcQikCOfwZClSBL8UD+5eJJ4=";
+    "https://github.com/Plutonomicon/plutarch-plutus"."fcdd2209433d8b8979e820dc4fa9aad5f202216d" = "sha256-gQwaYGIds5owHivXi+ktH7CGeBqoLBykVxyHZZiDUM4=";
   };
 }


### PR DESCRIPTION
This PR is still WIP. The dependency should be updated as soon as the bump is done in plutarch-plutus.
In particular, the next blocker is: https://github.com/Plutonomicon/plutarch-plutus/pull/677