### PR TITLE
Add marker tracing helper

### DIFF
--- a/liqwid-plutarch-extra/CHANGELOG.md
+++ b/liqwid-plutarch-extra/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 4.0.1 --- 2024-06-04
+
+### Added
+
+- `markInfoC` and `markDebugC` in `Plutarch.Extra.TermCont` for 'marker tracing'
+  for specific functions
+
 ## 4.0.0
 
 Internally:

--- a/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
+++ b/liqwid-plutarch-extra/liqwid-plutarch-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               liqwid-plutarch-extra
-version:            4.0.0
+version:            4.0.1
 synopsis:           A collection of Plutarch extras from Liqwid Labs
 description:        Several useful data types and functions for Plutarch.
 homepage:           https://github.com/Liqwid-Labs/liqwid-plutarch-extra

--- a/liqwid-plutarch-extra/src/Plutarch/Extra/TermCont.hs
+++ b/liqwid-plutarch-extra/src/Plutarch/Extra/TermCont.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE PolyKinds #-}
 
 module Plutarch.Extra.TermCont (
+  -- * Conditional guards
   pguardWithC,
   pguardShowC,
+  -- * Marker logging
+  markInfoC,
+  markDebugC
 ) where
 
 {- | 'pguardC' but with type threading for better traces.
@@ -47,3 +51,39 @@ pguardShowC ::
   TermCont @r s ()
 pguardShowC message =
   pguardWithC (\t -> message <> " Guarded object was: " <> pshow t)
+
+-- | Given an action, a pre-action marker and a post-action marker, log the
+-- pre-action marker, do the action, then log the post-action marker. All
+-- logging will be done in info mode.
+--
+-- This runs in 'TermCont' to ensure sensible sequencing.
+--
+-- @since 4.0.1
+markInfoC :: forall (r :: S -> Type) (a :: S -> Type) (s :: S) . 
+  -- | Pre-action marker
+  Term s PString -> 
+  -- | Post-action marker
+  Term s PString -> 
+  TermCont @r s (Term s a) -> 
+  TermCont @r s (Term s a)
+markInfoC pre post act = do
+  tcont $ \f -> ptraceInfo pre (f ())
+  x <- act
+  tcont $ \f -> ptraceInfo post (f ())
+  pure x
+
+-- | As 'markInfoC', but using debug tracing mode instead.
+--
+-- @since 4.0.1
+markDebugC :: forall (r :: S -> Type) (a :: S -> Type) (s :: S) . 
+  -- | Pre-action marker
+  Term s PString -> 
+  -- | Post-action marker
+  Term s PString -> 
+  TermCont @r s (Term s a) -> 
+  TermCont @r s (Term s a)
+markDebugC pre post act = do
+  tcont $ \f -> ptraceDebug pre (f ())
+  x <- act
+  tcont $ \f -> ptraceDebug post (f ())
+  pure x


### PR DESCRIPTION
This is designed to help with cases where we need to mark in our traces that a certain function ran.